### PR TITLE
Update hyprlock.conf

### DIFF
--- a/hyprlock.conf
+++ b/hyprlock.conf
@@ -383,17 +383,17 @@ shape {
 }
 
 # MEDIA BG
-#image {
+image {
     monitor     =
-    path        = $imgPath/media-bg-dark-25.png 
-    size        = 120 # lesser side if not 1:1 ratio
+    path        = $imgPath/media-bg-dark-25.png
+    size        = 8% # Prozentual zur Bildschirmgröße
     opacity     = 0.25
-    
-    rounding            = 5 # negative values mean circle
+
+    rounding            = 5
     border_size         = 0
-    rotate              = 0 # degrees, counter-clockwise
-    
-    position            = 0, -410
+    rotate              = 0
+
+    position            = 0, -10% # Prozentuale Position
     halign              = center
     valign              = center
     zindex              = 1
@@ -401,33 +401,32 @@ shape {
 
 shape {
     monitor     =
-    size        = 550, 120
-    
+    size        = 35%, 8% # Prozentuale Größe basierend auf Bildschirm
+
     shadow_passes       = $text-shadow-pass
     shadow_boost        = $text-shadow-boost
 
     color               = $shape-col1
     rounding            = $rounding
-    border_size         = 
+    border_size         =
     border_color        =
 
-    position            = 0, 70
+    position            = 0, 5%
     halign              = center
     valign              = bottom
     zindex              = 1
 }
 
-
-# PLAYER TITTLE
+# PLAYER TITLE
 label {
     monitor     =
     text        = cmd[update:1000] echo "$($scrPath/playerctl.sh --title)"
-    
+
     color               = $fg0
     font_size           = 14
     font_family         = $font-text
-    
-    position            = 0, -400
+
+    position            = 0, -40%
     halign              = center
     valign              = center
     zindex              = 5
@@ -437,12 +436,12 @@ label {
 label {
     monitor     =
     text        = cmd[update:1000] echo "$($scrPath/playerctl.sh --artist)"
-    
+
     color               = $fg0
     font_size           = 11
     font_family         = $font-text
-    
-    position            = 0, -420
+
+    position            = 0, -42%
     halign              = center
     valign              = center
     zindex              = 5
@@ -452,12 +451,12 @@ label {
 label {
     monitor     =
     text        = cmd[update:1000] echo "$($scrPath/playerctl.sh --album)"
-    
-    color               = $fg0
-    font_size           = 11 
-    font_family         = $font-text0    
 
-    position            = 0, -445
+    color               = $fg0
+    font_size           = 11
+    font_family         = $font-text0
+
+    position            = 0, -44%
     halign              = center
     valign              = center
     zindex              = 5
@@ -467,12 +466,12 @@ label {
 label {
     monitor     =
     text        = cmd[update:1000] echo "$($scrPath/playerctl.sh --status-symbol)"
-    
+
     color               = $fg0
     font_size           = 16
     font_family         = $font-symbol
-    
-    position            = 700, -370
+
+    position            = 33.5%, -38%
     halign              = left
     valign              = center
     zindex              = 5
@@ -482,12 +481,12 @@ label {
 label {
     monitor     =
     text        = cmd[update:1000] echo "$($scrPath/playerctl.sh --status)"
-    
+
     color               = $fg0
     font_size           = 10
-    font_family         = $font-text 
-    
-    position            = 720, -370
+    font_family         = $font-text
+
+    position            = 35%, -38%
     halign              = left
     valign              = center
     zindex              = 5
@@ -497,12 +496,12 @@ label {
 label {
     monitor     =
     text        = cmd[update:1000] echo "$($scrPath/playerctl.sh --source-symbol)"
-    
+
     color               = rgba(255, 255, 255, 0.6)
     font_size           = 16
     font_family         = $font-symbol
-    
-    position            = -700, -370
+
+    position            = -33.5%, -38%
     halign              = right
     valign              = center
     zindex              = 5
@@ -512,12 +511,12 @@ label {
 label {
     monitor     =
     text        = cmd[update:1000] echo "$($scrPath/playerctl.sh --source)"
-    
+
     color               = rgba(255, 255, 255, 0.6)
     font_size           = 10
-    font_family         = $font-text 
-    
-    position            = -720, -370
+    font_family         = $font-text
+
+    position            = -35%, -38%
     halign              = right
     valign              = center
     zindex              = 5
@@ -525,15 +524,14 @@ label {
 
 label {
     monitor     =
-    text        = 
+    text        =
 
     color               = $fg0
     font_size           = 24
     font_family         = $font-symbol
 
-    position            = 0, 15
+    position            = 0, 1%
     halign              = center
     valign              = bottom
 }
-
 

--- a/hyprlock.conf
+++ b/hyprlock.conf
@@ -386,14 +386,14 @@ shape {
 image {
     monitor     =
     path        = $imgPath/media-bg-dark-25.png
-    size        = 8% # Prozentual zur Bildschirmgröße
+    size        = 8% 
     opacity     = 0.25
 
     rounding            = 5
     border_size         = 0
     rotate              = 0
 
-    position            = 0, -10% # Prozentuale Position
+    position            = 0, -10% 
     halign              = center
     valign              = center
     zindex              = 1
@@ -401,7 +401,7 @@ image {
 
 shape {
     monitor     =
-    size        = 35%, 8% # Prozentuale Größe basierend auf Bildschirm
+    size        = 35%, 8% 
 
     shadow_passes       = $text-shadow-pass
     shadow_boost        = $text-shadow-boost
@@ -534,4 +534,5 @@ label {
     halign              = center
     valign              = bottom
 }
+
 


### PR DESCRIPTION
Looks a bit worse but now should work on any resolution in 16:9 and 9:16 format. I tested it on 1920x1080, 2540x1440 and 1080x1920 and the media is now displayed with ratios and not exact coordinates from a point